### PR TITLE
Fix mouse event handling

### DIFF
--- a/strictdom.js
+++ b/strictdom.js
@@ -820,7 +820,7 @@ function extend(parent, props) {
 }
 
 function isAttached(el) {
-  return el === window || document.contains(el);
+  return el instanceof Event || el === window || document.contains(el);
 }
 
 /**

--- a/test/test.js
+++ b/test/test.js
@@ -234,6 +234,29 @@ suite('strictdom', function() {
     });
   });
 
+  suite('MouseEvent', function() {
+    var evt;
+
+    setup(function() {
+      evt = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      });
+    });
+
+    test('.offsetX', function() {
+      var result = testMeasure(function() { return evt.offsetX; });
+      assert.equal(result, 0);
+    });
+
+    test('.offsetY', function() {
+      var result = testMeasure(function() { return evt.offsetY; });
+      assert.equal(result, 0);
+    });
+  });
+
+
   suite('HTMLImageElement', function() {
     var width = 512;
     var height = 532;


### PR DESCRIPTION
Check for an event to prevent the "Failed to execute 'contains' on 'Node': parameter 1 is not of type 'Node'" exception.